### PR TITLE
WIP: remove second instance of "query" in the response "params" for SSR

### DIFF
--- a/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
+++ b/packages/react-instantsearch-core/src/core/createInstantSearchManager.js
@@ -319,6 +319,19 @@ export default function createInstantSearchManager({
     }
   }
 
+  function removeDuplicateQuery(params) {
+    let previousIndex = undefined;
+    const queryParamRegex = /&?query=[^&]*/g;
+    return params.replace(queryParamRegex, function replacer(match, offset) {
+      if (previousIndex && offset > previousIndex) {
+        previousIndex = offset;
+        return '';
+      }
+      previousIndex = offset;
+      return match;
+    });
+  }
+
   function hydrateSearchClient(client, results) {
     if (!results) {
       return;
@@ -385,7 +398,7 @@ export default function createInstantSearchManager({
                 acc.concat(
                   result.rawResults.map(request => ({
                     indexName: request.index,
-                    params: request.params,
+                    params: removeDuplicateQuery(request.params),
                   }))
                 ),
               []
@@ -414,7 +427,7 @@ export default function createInstantSearchManager({
           acc.concat(
             result.rawResults.map(request => ({
               indexName: request.index,
-              params: request.params,
+              params: removeDuplicateQuery(request.params),
             }))
           ),
         []
@@ -442,7 +455,7 @@ export default function createInstantSearchManager({
           args: [
             results.rawResults.map(request => ({
               indexName: request.index,
-              params: request.params,
+              params: removeDuplicateQuery(request.params),
             })),
           ],
         },
@@ -461,7 +474,7 @@ export default function createInstantSearchManager({
     const key = `/1/indexes/*/queries_body_${JSON.stringify({
       requests: results.rawResults.map(request => ({
         indexName: request.index,
-        params: request.params,
+        params: removeDuplicateQuery(request.params),
       })),
     })}`;
 


### PR DESCRIPTION
fixes #2940

So far this is a pretty ugly option. I wonder if we can maybe make the cache ignore a second parameter? (that's probably not possible, since the key is a string, not an object)

- [ ] try out in more cases
- [ ] test performance (params might be LARGE)
- [ ] write tests

<!--
  Thanks for submitting a pull request!
  Please provide enough information so that others can review your pull request.
-->

**Summary**

<!--
  Explain the **motivation** for making this change.
  What existing problem does the pull request solve?
  Are there any linked issues?
-->

**Result**

<!--
  Demonstrate the code is solid.
  Example: The exact commands you ran and their output,
  screenshots / videos if the pull request changes UI.
-->
